### PR TITLE
Add support for updating OEM FRU data

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -20,12 +20,13 @@ def get_arg_parser():
     parser.add_argument('-U',             metavar="<username>",        dest="username",     type=str, required=True, help='Username of BMC')
     parser.add_argument('-P',             metavar="<password>",        dest="password",     type=str, required=True, help='Password of BMC')
     parser.add_argument('-F',             metavar="<firmware_file>",   dest="fw_file_path", type=str, required=False, help='Firmware file path (absolute/relative)')
-    parser.add_argument('-T',             metavar="<module>",          dest="module",       type=str, required=False, help='The module to be updated: BMC|CEC|BIOS', choices=('BMC', 'CEC', 'BIOS'))
+    parser.add_argument('-T',             metavar="<module>",          dest="module",       type=str, required=False, help='The module to be updated: BMC|CEC|BIOS|FRU', choices=('BMC', 'CEC', 'BIOS', 'FRU'))
     parser.add_argument('-H',             metavar="<bmc_ip>",          dest="bmc_ip",       type=str, required=True, help='IP/Host of BMC')
     parser.add_argument('-C',             action='store_true',         dest="clear_config",           required=False, help='Reset to factory configuration (Only used for BMC|BIOS)')
     parser.add_argument('-o', '--output', metavar="<output_log_file>", dest="output_file",  type=str, required=False, help='Output log file')
     parser.add_argument('-p', '--port',   metavar="<bmc_port>",        dest="bmc_port",     type=str, required=False, help='Port of BMC (443 by default).')
     parser.add_argument('--bios_update_protocol', metavar='<bios_update_protocol>', dest="bios_update_protocol", required=False, help=argparse.SUPPRESS, choices=('HTTP', 'SCP'))
+    parser.add_argument('-s',             action='append',             metavar="<oem_fru>", dest="oem_fru",           type=str, required=False, help='FRU data in the format "Section:Key=Value"')
     parser.add_argument('-v', '--version',     action='store_true',    dest="show_version",           required=False, help='Show the version of this scripts')
     parser.add_argument('--skip_same_version', action='store_true',    dest="skip_same_version",      required=False, help='Do not upgrade, if upgrade version is the same as current running version')
     parser.add_argument('--show_all_versions', action='store_true',    dest="show_all_versions",      required=False, help=argparse.SUPPRESS)
@@ -48,6 +49,7 @@ def main():
                                                  args.password,
                                                  args.fw_file_path,
                                                  args.module,
+                                                 args.oem_fru,
                                                  args.skip_same_version,
                                                  args.debug,
                                                  args.output_file,

--- a/OobUpdate.sh
+++ b/OobUpdate.sh
@@ -27,4 +27,4 @@ function check_and_set_env()
 
 check_and_set_env
 
-python3 $PY_SCRIPT $@
+python3 $PY_SCRIPT "$@"

--- a/README.md
+++ b/README.md
@@ -20,20 +20,21 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
       -U <username>         Username of BMC
       -P <password>         Password of BMC
       -F <firmware_file>    Firmware file path (absolute/relative)
-      -T <module>           The module to be updated: BMC|CEC|BIOS
+      -T <module>           The module to be updated: BMC|CEC|BIOS|FRU
       -H <bmc_ip>           IP/Host of BMC
       -C                    Reset to factory configuration (Only used for BMC|BIOS)
       -o <output_log_file>, --output <output_log_file>
                             Output log file
       -p <bmc_port>, --port <bmc_port>
                             Port of BMC
+      -s <oem_fru>          FRU data in the format Section:Key=Value
       -v, --version         Show the version of this scripts
       --skip_same_version   Do not upgrade, if upgrade version is the same as
                             current running version
       -d, --debug           Show more debug info
 
 ## Example
-Update BMC firmware
+### Update BMC firmware
 
     # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98  -T BMC -F /opt/bf3-bmc-24.04-5_ipn.fwpkg
     Start to upload firmware
@@ -45,7 +46,7 @@ Update BMC firmware
     New BMC Firmware Version:
             BF-24.04-5
 
-Update CEC firmware
+### Update CEC firmware
 
     # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98  -T CEC -F /opt/cec1736-ecfw-00.02.0182.0000-n02-rel-debug.fwpkg
     Start to upload firmware
@@ -57,7 +58,7 @@ Update CEC firmware
     New CEC Firmware Version:
             00.02.0182.0000_n02
 
-Update BIOS firmware
+### Update BIOS firmware
 
     # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98  -T BIOS -F /opt/BlueField-4.7.0.13127_preboot-install.bfb
     Start to upload firmware
@@ -69,6 +70,70 @@ Update BIOS firmware
     New BIOS Firmware Version:
             ATF--v2.2(release):4.7.0-25-g5569834, UEFI--4.7.0-42-g13081ae
 
+### Update FRU data
+
+The following OEM fields can be modified by the user:
+
+- Product Manufacturer
+- Product Serial Number
+- Product Part Number
+- Product Version
+- Product Extra
+- Product Manufacture Date (format is "DD/MM/YYYY HH:MM:SS")
+- Product Asset Tag
+- Product GUID (Chassis Extra in ipmitool)
+
+All OEM fields must be set in the command. If a specified FRU field is left empty, the value for that field will be ignored but not overridden.
+
+To write the FRU with the relevant data, use the following command:
+
+    # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98 -T FRU -s "Product:Manufacturer=OEM" -s "Product:SerialNumber=AB12345CD6" -s "Product:PartNumber=100-1D2B3-456V-789" -s "Product:Version=1.0" -s "Product:Extra=abc" -s "Product:ManufactureDate=05/07/2021 01:00:00" -s "Product:AssetTag=1.0.0" -s "Product:GUID=AB12345CD6"
+    OEM FRU data to be updated: {
+        "ProductManufacturer": "OEM",
+        "ProductSerialNumber": "AB12345CD6",
+        "ProductPartNumber": "100-1D2B3-456V-789",
+        "ProductVersion": "1.0",
+        "ProductExtra": "abc",
+        "ProductManufactureDate": "05/07/2021 01:00:00",
+        "ProductAssetTag": "1.0.0",
+        "ProductGUID": "AB12345CD6"
+    }
+    OEM FRU data updated successfully.
+
+To assign empty values to specfic fields, use the following command:
+
+    # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98 -T FRU -s "Product:Manufacturer=OEM" -s "Product:SerialNumber=AB12345CD6" -s "Product:PartNumber=100-1D2B3-456V-789" -s "Product:Version=1.0" -s "Product:Extra=abc" -s "Product:ManufactureDate=05/07/2021 01:00:00" -s "Product:AssetTag=" -s "Product:GUID="
+    OEM FRU data to be updated: {
+        "ProductManufacturer": "OEM",
+        "ProductSerialNumber": "AB12345CD6",
+        "ProductPartNumber": "100-1D2B3-456V-789",
+        "ProductVersion": "1.0",
+        "ProductExtra": "abc",
+        "ProductManufactureDate": "05/07/2021 01:00:00",
+        "ProductAssetTag": "",
+        "ProductGUID": ""
+    }
+    OEM FRU data updated successfully.
+
+To assign empty values to all fields, use the following command:
+
+    # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98 -T FRU -s "Product:Manufacturer=" -s "Product:SerialNumber=" -s "Product:PartNumber=" -s "Product:Version=" -s "Product:Extra=" -s "Product:ManufactureDate=" -s "Product:AssetTag=" -s "Product:GUID="
+    OEM FRU data to be updated: {
+        "ProductManufacturer": "",
+        "ProductSerialNumber": "",
+        "ProductPartNumber": "",
+        "ProductVersion": "",
+        "ProductExtra": "",
+        "ProductManufactureDate": "",
+        "ProductAssetTag": "",
+        "ProductGUID": ""
+    }
+    OEM FRU data updated successfully.
+
+To ensure the FRU writing takes effect, follow these steps:
+- Send Command to BMC: Set the desired OEM data by sending a command to the BMC.
+- Reboot the DPU: This will update the SMBIOS table on the DPU, and the dmidecode output will reflect the changes.
+- Reboot the BMC: This will update the FRU information on the BMC accordingly.
 
 ## Precondition (Controller Host)
 1. Avaiable connection to DPU BMC

--- a/src/error_num.py
+++ b/src/error_num.py
@@ -39,6 +39,7 @@ class Err_Num(Enum):
     HTTP_FILE_SERVER_NOT_ACCESSIBLE       = 28
     INVALID_BMC_ADDRESS                   = 29
     CURL_COMMAND_FAILED                   = 30
+    INVALID_INPUT_PARAMETER               = 31
     OTHER_EXCEPTION                       = 127
 
 
@@ -73,6 +74,7 @@ Err_Str = {
    Err_Num.HTTP_FILE_SERVER_NOT_ACCESSIBLE : 'HTTP file server is not accessible from BMC',
    Err_Num.INVALID_BMC_ADDRESS            : 'Invalid BMC Address',
    Err_Num.CURL_COMMAND_FAILED            : 'Curl command failed',
+   Err_Num.INVALID_INPUT_PARAMETER        : 'The input parameter provided is invalid',
    Err_Num.OTHER_EXCEPTION                : 'Other Errors',
 }
 

--- a/src/http_accessor_requests.py
+++ b/src/http_accessor_requests.py
@@ -34,6 +34,8 @@ class HTTP_Accessor(object):
             return self._http_post(data=data)
         elif self.method == 'PATCH':
             return self._http_patch(data=data)
+        elif self.method == 'PUT':
+            return self._http_put(data=data)
 
 
     def multi_part_push(self, multi_part_general_param):
@@ -95,6 +97,15 @@ class HTTP_Accessor(object):
     @connection_exception
     def _http_patch(self, data):
         return requests.patch(self.url,
+                              data=data,
+                              headers=self.headers,
+                              auth=(self.username, self.password),
+                              verify=False,
+                              timeout=self.timeout)
+
+    @connection_exception
+    def _http_put(self, data):
+        return requests.put(self.url,
                               data=data,
                               headers=self.headers,
                               auth=(self.username, self.password),


### PR DESCRIPTION
- Added a new command-line argument `-s` to `OobUpdate.py` for specifying OEM FRU data.
- Added a new module name `FRU` to the `module` parameter
- Modified `bf_dpu_update.py` to handle the new `-s` argument and update OEM FRU data via an HTTP PUT request.
- Updated `README.md` to document the new argument

RM #4064400