### PR TITLE
Remove required fields checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
 
     OobUpdate.sh [-h] [-U <username>] [-P <password>] [-F <firmware_file>]
                  [-T <module>] [-H <bmc_ip>] [-C <clear_config>]
-                 [-o <output_log_file>] [-p <bmc_port>] [-v]
+                 [-o <output_log_file>] [-p <bmc_port>] [-s <oem_fru>] [-v]
                  [--skip_same_version] [-d]
 
     optional arguments:
@@ -83,7 +83,18 @@ The following OEM fields can be modified by the user:
 - Product Asset Tag
 - Product GUID (Chassis Extra in ipmitool)
 
-All OEM fields must be set in the command. If a specified FRU field is left empty, the value for that field will be ignored but not overridden.
+If a specified FRU field is left empty value, the value for that field will default to the original Nvidia FRU information.
+If a specified FRU field is not set, the OEM FRU data will remain unchanged.
+
+To update each FRU field, use the format "Section:Key=Value". Example:
+- Product Manufacturer (Product:Manufacturer)
+- Product Serial Number (Product:SerialNumber)
+- Product Part Number (Product:PartNumber)
+- Product Version (Product:Version)
+- Product Extra (Product:Extra)
+- Product Manufacture Date (Product:ManufactureDate)
+- Product Asset Tag (Product:AssetTag)
+- Product GUID (Product:GUID)
 
 To write the FRU with the relevant data, use the following command:
 
@@ -130,8 +141,17 @@ To assign empty values to all fields, use the following command:
     }
     OEM FRU data updated successfully.
 
+To assign values to specific supported OEM fields, use the following command::
+
+    # ./OobUpdate.sh -U root -P Nvidia20240604-- -H 10.237.121.98 -T FRU -s "Product:Manufacturer=OEM" -s "Product:SerialNumber=AB12345CD6"
+    OEM FRU data to be updated: {
+        "ProductManufacturer": "OEM",
+        "ProductSerialNumber": "AB12345CD6"
+    }
+    OEM FRU data updated successfully.
+
 To ensure the FRU writing takes effect, follow these steps:
-- Send Command to BMC: Set the desired OEM data by sending a command to the BMC.
+- Run the Script Command: Set the desired OEM data by sending the script command to the BMC.
 - Reboot the DPU: This will update the SMBIOS table on the DPU, and the dmidecode output will reflect the changes.
 - Reboot the BMC: This will update the FRU information on the BMC accordingly.
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1008,20 +1008,10 @@ class BF_DPU_Update(object):
         Update the OEM FRU data with the provided key-value pairs in the format 'Section:Key=Value'
         """
 
-        # Define the required fields for the OEM FRU data
-        required_fields = {
-            'Product:Manufacturer',
-            'Product:SerialNumber',
-            'Product:PartNumber',
-            'Product:Version',
-            'Product:Extra',
-            'Product:ManufactureDate',
-            'Product:AssetTag',
-            'Product:GUID'
-        }
-
+        # Check if the user has set the parameter in self.oem_fru
+        if not self.oem_fru:
+            raise Err_Exception(Err_Num.INVALID_INPUT_PARAMETER, "No OEM FRU data provided. Please set the parameter for OEM FRU.")
         oem_fru_dict = {}
-        provided_fields = set()
         if self.debug:
             print("OEM FRU data to be updated:", self.oem_fru)
         # Process each item in the provided OEM FRU data
@@ -1037,16 +1027,10 @@ class BF_DPU_Update(object):
                 # Validate ManufactureDate format
                 if section_key == 'Product:ManufactureDate' and not self._validate_fru_date_format(value):
                     raise Err_Exception(Err_Num.INVALID_INPUT_PARAMETER, "Invalid date format for ManufactureDate. Expected format: DD/MM/YYYY HH:MM:SS")
-                provided_fields.add(section_key)
                 if self.debug:
                     print(f"Updated FRU field: {section_key} with value: {value}")
             except ValueError:
                 raise Err_Exception(Err_Num.INVALID_INPUT_PARAMETER, "Invalid format for OEM FRU data: {}. Expected format 'Section:Key=Value'".format(item))
-
-        # Process each item in the provided OEM FRU data
-        missing_fields = required_fields - provided_fields
-        if missing_fields:
-            raise Err_Exception(Err_Num.INVALID_INPUT_PARAMETER, "Missing required OEM FRU fields: {}".format(', '.join(missing_fields)))
 
         print("OEM FRU data to be updated:", json.dumps(oem_fru_dict, indent=4))
 


### PR DESCRIPTION
Removed the required fields check from the update_oem_fru method in bf_dpu_update.py to allow more flexible updates. User do not need to update all the FRU fields each time.

If a specified FRU field is not set, the OEM FRU data will remain unchanged.
If a specified FRU field is left empty, the value for that field will default to the original Nvidia FRU information.

RM #4064400