### PR TITLE
Use timestamp+pid as the temp CURL output file name

### DIFF
--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -382,7 +382,7 @@ class BF_DPU_Update(object):
         }
         response = self._http_post(url, data=json.dumps(data), headers=headers)
         self.log('Update BFB Firmware', response)
-        self._handle_status_code(response, [200, 202], self._update_in_progress_err_handler)
+        self._handle_status_code(response, [100, 200, 202], self._update_in_progress_err_handler)
         return self._extract_task_handle(response)
 
 
@@ -448,7 +448,7 @@ class BF_DPU_Update(object):
         response = self._multi_part_push(url, multi_part_param)
 
         self.log('Update Firmware', response)
-        self._handle_status_code(response, [200, 202], self._update_in_progress_err_handler)
+        self._handle_status_code(response, [100, 200, 202], self._update_in_progress_err_handler)
         return self._extract_task_handle(response)
 
 
@@ -458,7 +458,7 @@ class BF_DPU_Update(object):
         }
         response = self._upload_file(url, self.fw_file_path, headers=headers)
         self.log('Update Firmware', response)
-        self._handle_status_code(response, [200, 202], self._update_in_progress_err_handler)
+        self._handle_status_code(response, [100, 200, 202], self._update_in_progress_err_handler)
         return self._extract_task_handle(response)
 
 

--- a/src/http_accessor_curl.py
+++ b/src/http_accessor_curl.py
@@ -84,8 +84,9 @@ class HTTP_Accessor(object):
                 header_param += '-H "{}: {}" '.format(k, self.headers[k])
 
         ts = str(time.time())
-        resp_body_file    = '/tmp/dpu_update_resp_body_{}.txt'.format(ts)
-        resp_headers_file = '/tmp/dpu_update_resp_headers_{}.txt'.format(ts)
+        pid = os.getpid()
+        resp_body_file    = '/tmp/dpu_update_resp_body_{}_{}.txt'.format(ts, pid)
+        resp_headers_file = '/tmp/dpu_update_resp_headers_{}_{}.txt'.format(ts, pid)
 
         output_param  = '-D {} -o {}'.format(resp_headers_file, resp_body_file)
         auth_param    = "-u '{}':'{}'".format(self.username, self.password)
@@ -103,7 +104,7 @@ class HTTP_Accessor(object):
 
         resp_body    = self._read_file(resp_body_file)
         resp_headers = self._read_file(resp_headers_file)
-        os.system('rm -f /tmp/dpu_update_resp*')
+        os.system('rm -f {} {}'.format(resp_body_file, resp_headers_file))
 
         request  = CURL_Request(self.url, self.method, command)
         response = CURL_Response(resp_body, resp_headers, request)


### PR DESCRIPTION
1: Use timestamp+pid as the temp CURL output file name
2: Add 100 as additional valid HTTP status code
