### PR TITLE
Fix -o logfile error

### DIFF
--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -651,7 +651,7 @@ class BF_DPU_Update(object):
         if not os.access(self.fw_file_path, os.R_OK):
             raise Err_Exception(Err_Num.FILE_NOT_ACCESSIBLE, 'Firmware file: {}'.format(self.fw_file_path))
 
-        if self.log_file is not None and not os.access(self.log_file, os.W_OK) and not os.access(os.path.dirname(self.log_file), os.W_OK):
+        if self.log_file is not None and not os.access(self.log_file, os.W_OK) and not os.access(os.path.abspath(os.path.dirname(self.log_file)), os.W_OK):
             raise Err_Exception(Err_Num.FILE_NOT_ACCESSIBLE, 'Log file: {}'.format(self.log_file))
         return True
 


### PR DESCRIPTION
Issue:
When use provide logfile like -o abc.log without path. There will be an error saying "File is not accessible; Log file: abc.log"

Cause:
os.access(os.path.dirname('abc.log'), os.W_OK) return False, since os.path.dirname('abc.log') return empty path. Then, os.access('', os.W_OK) will return False for any case.

Solution:
Get absolute path of the log file, to avoid empty path.