### PR TITLE
Avoid using of os.system

### DIFF
--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -436,7 +436,7 @@ class BF_DPU_Update(object):
         port = None
         with open(self._http_server_port_file, 'r') as f:
             port = int(f.read())
-        os.system('rm -f {}'.format(self._http_server_port_file))
+        os.remove(self._http_server_port_file)
         self._local_http_server_port = port
         if not self._http_server_process.is_alive() or self._local_http_server_port is None:
             raise Err_Exception(Err_Num.FAILED_TO_START_HTTP_SERVER)

--- a/src/http_accessor_curl.py
+++ b/src/http_accessor_curl.py
@@ -104,7 +104,8 @@ class HTTP_Accessor(object):
 
         resp_body    = self._read_file(resp_body_file)
         resp_headers = self._read_file(resp_headers_file)
-        os.system('rm -f {} {}'.format(resp_body_file, resp_headers_file))
+        os.remove(resp_body_file)
+        os.remove(resp_headers_file)
 
         request  = CURL_Request(self.url, self.method, command)
         response = CURL_Response(resp_body, resp_headers, request)


### PR DESCRIPTION
os.system is not safe, and not portable.
And , the performance is not good.
https://www.quora.com/Is-it-still-a-bad-practice-to-use-OS-system-in-Python-if-the-argument-is-a-string-constant-and-not-a-command-taken-from-the-user

Instead, use os.remove to delete tmp file.