### PR TITLE
Wait for DPU ready for upto 3 minutes

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -22,7 +22,7 @@ def get_arg_parser():
     parser.add_argument('-F',             metavar="<firmware_file>",   dest="fw_file_path", type=str, required=False, help='Firmware file path (absolute/relative)')
     parser.add_argument('-T',             metavar="<module>",          dest="module",       type=str, required=False, help='The module to be updated: BMC|CEC|BIOS|FRU|CONFIG', choices=('BMC', 'CEC', 'BIOS', 'FRU', 'CONFIG'))
     parser.add_argument('-H',             metavar="<bmc_ip>",          dest="bmc_ip",       type=str, required=False, help='IP/Host of BMC')
-    parser.add_argument('-C',             action='store_true',         dest="clear_config",           required=False, help='Reset to factory configuration (Only used for BMC|BIOS)')
+    parser.add_argument('-C',             action='store_true',         dest="clear_config",           required=False, help='Reset to factory configuration (Only used for BMC|BIOS|CONFIG)')
     parser.add_argument('-o', '--output', metavar="<output_log_file>", dest="output_file",  type=str, required=False, help='Output log file')
     parser.add_argument('-p', '--port',   metavar="<bmc_port>",        dest="bmc_port",     type=str, required=False, help='Port of BMC (443 by default).')
     parser.add_argument('--bios_update_protocol', metavar='<bios_update_protocol>', dest="bios_update_protocol", required=False, help=argparse.SUPPRESS, choices=('HTTP', 'SCP'))


### PR DESCRIPTION
Before this patch, it poll the DPU state for upto 100 times. for each time, it may take about ~2(redfish) + 4(sleep) seconds. That means it will take about 10 minutes to timeout. The timeout value depends on the timeout used on redfish command.

After this patch, the timeout value is exactly 3 minutes. It does not depend on the redfish command.