### PR TITLE
Switch the order of BMC/BIOS factory reset when update CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
     # ./OobUpdate.sh -U dingzhi -P Nvidia20240604-- -H 10.237.121.98  -T CONFIG -F /opt/BD-config-image-4.9.0.13354-1.0.0.bfb
     Start to Simple Update (HTTP)
     Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-    Factory reset BMC configuration
-    Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     Factory reset BIOS configuration(ResetBios) (will reboot the system)
     Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    Factory reset BMC configuration
+    Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 ### Update FRU data
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -569,7 +569,14 @@ class BF_DPU_Update(object):
 
 
     def _wait_for_bmc_on(self):
-        for i in range(1, 101):
+        timeout = 60 * 3 # Wait up to 3 minutes
+        start   = int(time.time())
+        end     = start + timeout
+        while True:
+            cur = int(time.time())
+            if cur > end:
+                self._print_process(100)
+                break
             time.sleep(4)
             try:
                 self.get_ver('BMC')
@@ -577,7 +584,7 @@ class BF_DPU_Update(object):
                 self._print_process(100)
                 break
             except Exception as e:
-                self._print_process(i)
+                self._print_process(100 * (cur - start) / timeout)
         print()
 
 
@@ -1169,11 +1176,11 @@ class BF_DPU_Update(object):
         # 1. Update config image in DPU BMC Flash using Redfish
         self._start_and_wait_simple_update_task()
 
-        # 2. BMC Factory reset flow shall be triggered in order to clean old configuration (e.g., old users)
-        self.factory_reset_bmc()
-
-        # 3. In order to update the ARM UPVS partition and the corresponding UEFI capsule in eMMC, a factory reset should be triggered
+        # 2. In order to update the ARM UPVS partition and the corresponding UEFI capsule in eMMC, a factory reset should be triggered
         self.send_reset_bios()
+
+        # 3. BMC Factory reset flow shall be triggered in order to clean old configuration (e.g., old users)
+        self.factory_reset_bmc()
 
 
     def do_update(self):


### PR DESCRIPTION
Problem:
BMC factory reset will clear the static IP of BMC, which cause loss connection to BMC. Then script can not continue to do remaining tasks.
Solution:
Do the BMC factory reset at last

Also, optimize the wait timeout for BMC on. The timeout now will be stable at 3 minutes