### PR TITLE
Add eMMC wipe functionality to BF_DPU_Update

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -23,6 +23,7 @@ def get_arg_parser():
     parser.add_argument('-T',             metavar="<module>",          dest="module",       type=str, required=False, help='The module to be updated: BMC|CEC|BIOS|FRU|CONFIG', choices=('BMC', 'CEC', 'BIOS', 'FRU', 'CONFIG'))
     parser.add_argument('-H',             metavar="<bmc_ip>",          dest="bmc_ip",       type=str, required=False, help='IP/Host of BMC')
     parser.add_argument('-C',             action='store_true',         dest="clear_config",           required=False, help='Reset to factory configuration (Only used for BMC|BIOS)')
+    parser.add_argument('-E',             action='store_true',         dest="wipe_emmc",              required=False, help='Wipe eMMC during the configuration image update (Only used for CONFIG)')
     parser.add_argument('-o', '--output', metavar="<output_log_file>", dest="output_file",  type=str, required=False, help='Output log file')
     parser.add_argument('-p', '--port',   metavar="<bmc_port>",        dest="bmc_port",     type=str, required=False, help='Port of BMC (443 by default).')
     parser.add_argument('--bios_update_protocol', metavar='<bios_update_protocol>', dest="bios_update_protocol", required=False, help=argparse.SUPPRESS, choices=('HTTP', 'SCP'))
@@ -58,6 +59,7 @@ def main():
                                                  args.oem_fru,
                                                  args.skip_same_version,
                                                  args.debug,
+                                                 args.wipe_emmc,
                                                  args.output_file,
                                                  bfb_update_protocol = args.bios_update_protocol,
                                                  use_curl = True)

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
       -T <module>           The module to be updated: BMC|CEC|BIOS|FRU|CONFIG
       -H <bmc_ip>           IP/Host of BMC
       -C                    Reset to factory configuration (Only used for BMC|BIOS)
+      -E                    Wipe eMMC during the configuration image update (Only used for CONFIG)
       -o <output_log_file>, --output <output_log_file>
                             Output log file
       -p <bmc_port>, --port <bmc_port>
@@ -76,6 +77,17 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
     Start to Simple Update (HTTP)
     Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     Factory reset BIOS configuration (ResetBios) (will reboot the system)
+    Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    Restart BMC to make new firmware take effect
+    Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+
+Wipe eMMC during image update:
+
+    # ./OobUpdate.sh -U dingzhi -P Nvidia20240604-- -H 10.237.121.98  -T CONFIG -E -F /opt/BD-config-image-4.9.0.13354-1.0.0.bfb
+    Wiping eMMC (EmmcWipe)
+    Start to Simple Update (HTTP)
+    Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    Factory reset BIOS configuration(ResetBios) (will reboot the system)
     Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     Restart BMC to make new firmware take effect
     Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░


### PR DESCRIPTION
- Integrated eMMC wipe step into the firmware update process.
- Implemented send_emmc_wipe method to wipe the eMMC and reboot the system.