### PR TITLE
Support --config to update config

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -12,7 +12,7 @@ import bf_dpu_update
 
 
 # Version of this script tool
-Version = '24.10-4.2'
+Version = '24.10-5.0'
 
 
 def get_arg_parser():
@@ -26,6 +26,7 @@ def get_arg_parser():
     parser.add_argument('-o', '--output', metavar="<output_log_file>", dest="output_file",  type=str, required=False, help='Output log file')
     parser.add_argument('-p', '--port',   metavar="<bmc_port>",        dest="bmc_port",     type=str, required=False, help='Port of BMC (443 by default).')
     parser.add_argument('--bios_update_protocol', metavar='<bios_update_protocol>', dest="bios_update_protocol", required=False, help=argparse.SUPPRESS, choices=('HTTP', 'SCP'))
+    parser.add_argument('--config',       metavar='<config_file>',     dest="config_file",  type=str, required=False, help='Configuration file')
     parser.add_argument('-s',             action='append',             metavar="<oem_fru>", dest="oem_fru",           type=str, required=False, help='FRU data in the format "Section:Key=Value"')
     parser.add_argument('-v', '--version',     action='store_true',    dest="show_version",           required=False, help='Show the version of this scripts')
     parser.add_argument('--skip_same_version', action='store_true',    dest="skip_same_version",      required=False, help='Do not upgrade, if upgrade version is the same as current running version')
@@ -68,6 +69,21 @@ def main():
 
         if args.fw_file_path is not None or args.oem_fru is not None:
             dpu_update.do_update()
+
+        if args.config_file is not None:
+            dpu_config = bf_dpu_update.BF_DPU_Update(args.bmc_ip,
+                                                     args.bmc_port,
+                                                     args.username,
+                                                     args.password,
+                                                     args.config_file,
+                                                     'CONFIG',
+                                                     args.oem_fru,
+                                                     args.skip_same_version,
+                                                     args.debug,
+                                                     args.output_file,
+                                                     bfb_update_protocol = args.bios_update_protocol,
+                                                     use_curl = True)
+            dpu_config.do_update()
 
         if args.clear_config:
             dpu_update.reset_config()

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
                             Output log file
       -p <bmc_port>, --port <bmc_port>
                             Port of BMC
+      --config <config_file>
+                            Configuration file
       -s <oem_fru>          FRU data in the format Section:Key=Value
       -v, --version         Show the version of this scripts
       --skip_same_version   Do not upgrade, if upgrade version is the same as
@@ -45,6 +47,24 @@ OobUpdate.sh is a program for updating various component firmware of BlueField D
             BF-24.03-4
     New BMC Firmware Version:
             BF-24.04-5
+
+### Combine BMC firmware with config file update together
+
+    # ./OobUpdate.sh -U dingzhi -P Nvidia20240604-- -H 10.237.121.98  -T BMC -F /opt/bf3-bmc-24.04-5_ipn.fwpkg --config /opt/BD-config-image-4.9.0.13354-1.0.0.bfb
+    Start to upload firmware
+    Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    Restart BMC to make new firmware take effect
+    Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    OLD BMC Firmware Version:
+            BF-24.03-4
+    New BMC Firmware Version:
+            BF-24.04-5
+    Start to Simple Update (HTTP)
+    Process-: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    Factory reset BIOS configuration (ResetBios) (will reboot the system)
+    Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
+    Restart BMC to make new firmware take effect
+    Process|: 100%: ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 
 ### Update CEC firmware
 


### PR DESCRIPTION
If providing optional option --config <config_file> The script will go to update config by <config_file> after updating firmware.

For example:
  Following one command:
    -C BMC -F <fw_fle> --config <config_file>
  has the same effect as following two commands
    -C BMC -F <fw_fle>
    -C CONFI -F <config_file>