### PR TITLE
Catch specific exceptions of CEC reboot

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -12,7 +12,7 @@ import bf_dpu_update
 
 
 # Version of this script tool
-Version = '25.04-1.0'
+Version = '25.04-1.1'
 
 
 def get_arg_parser():

--- a/src/error_num.py
+++ b/src/error_num.py
@@ -47,6 +47,7 @@ class Err_Num(Enum):
     FW_FILE_NOT_GIVEN                     = 36
     FRU_NOT_GIVEN                         = 37
     UPDATE_SERVICE_NOT_READY              = 38
+    NO_PENDING_CEC_FW                     = 39
     OTHER_EXCEPTION                       = 127
 
 
@@ -67,7 +68,7 @@ Err_Str = {
    Err_Num.INVALID_STATUS_CODE            : 'Invalid response status code',
    Err_Num.FAILED_TO_GET_LOCAL_KEY        : 'Failed to get local SSH Key',
    Err_Num.FAILED_TO_ENABLE_BMC_RSHIM     : 'Failed to enable BMC rshim',
-   Err_Num.NOT_SUPPORT_CEC_RESTART        : 'CEC restart redfish API is not supported in this version',
+   Err_Num.NOT_SUPPORT_CEC_RESTART        : 'CEC reboot redfish API is not supported in this version',
    Err_Num.BMC_BACKGROUND_BUSY            : 'BMC is busy on background operation',
    Err_Num.PUBLIC_KEY_NOT_EXCHANGED       : 'Public key was not exchanged with BMC successfully',
    Err_Num.TASK_FAILED                    : 'Task failed',
@@ -89,6 +90,7 @@ Err_Str = {
    Err_Num.FW_FILE_NOT_GIVEN              : 'Firmware file is not given',
    Err_Num.FRU_NOT_GIVEN                  : 'FRU is not given',
    Err_Num.UPDATE_SERVICE_NOT_READY       : 'Update service is not ready(enabled)',
+   Err_Num.NO_PENDING_CEC_FW              : 'CEC firmware was not updated',
    Err_Num.OTHER_EXCEPTION                : 'Other Errors',
 }
 


### PR DESCRIPTION
There are two known exceptions when do CEC reboot: 
1: The CEC version does not support CEC reboot redfish api. 
2: If CEC firmware is not updated, CEC reboot command will be aborted. https://docs.nvidia.com/networking/display/bluefieldbmcv2501/cec+and+bmc+firmware+operations#src-3620319428_CECandBMCFirmwareOperations-ResettingCECandBMCSubsystemsUsingCECSelf-resetCommand

We should catch the two exceptions and print message accordingly, and let the script go on to execute remaining tasks

Update version from 25.04-1.0 to 25.04-1.1