### PR TITLE
Add warning when BMC components upgrade is skipped due to VLAN error (#4829441)

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.8'
+Version = '1.8.9'
 task_dir = None
 debug = False
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1810,11 +1810,38 @@ class BF_DPU_Update(object):
         if self.lfwp:
             self.enable_runtime_rshim()
         self._start_and_wait_simple_update_task()
+        rshim_vlan_error = False
         if self.lfwp:
             self.disable_runtime_rshim()
             time.sleep(120) # Wait for NIC fw to be updated and mlxfwreset to be done
         else:
-            self._wait_for_dpu_ready()
+            # Wait for DPU ready while checking rshim log for VLAN errors.
+            # The rshim log is cleared when the DPU reboots from eMMC,
+            # so we check it frequently (every 5s) to catch the narrow window
+            # between the error being logged and the log being cleared.
+            print('Waiting for the BFB installation to finish')
+            timeout = 60 * 40
+            start = int(time.time())
+            end   = start + timeout
+            while True:
+                cur = int(time.time())
+                if cur > end:
+                    self._print_process(100)
+                    break
+                state = self.get_dpu_boot_state()
+                if state == 'OsIsRunning':
+                    self._print_process(100)
+                    break
+                if not rshim_vlan_error:
+                    try:
+                        misc = self.get_bmc_rshim_misc()
+                        if 'Failed to create VLAN' in misc:
+                            rshim_vlan_error = True
+                    except Exception:
+                        pass
+                self._print_process(100 * (cur - start) / timeout)
+                time.sleep(5)
+            print()
             self._wait_for_system_power_on()
 
         if self.reset_bios and not self.lfwp:
@@ -1855,6 +1882,9 @@ class BF_DPU_Update(object):
         self._check_and_clear_sel_if_needed(old_bmc_ver, new_bmc_ver)
 
         self.show_old_new_versions(cur_vers, new_vers, ['BMC', 'CEC', 'ATF', 'UEFI', 'NIC'])
+
+        if rshim_vlan_error:
+            print('\nWARNING: BMC components upgrade was skipped. VLAN error detected in rshim log.')
 
         if self.lfwp:
             bfb_nic_fw_ver = self.get_info_data_version('NIC')


### PR DESCRIPTION
Initial state:
When VLAN 4040 is down during a BUNDLE update, bfb-install on the DPU fails to update BMC components and logs "ERR[MISC]: Failed to create VLAN." to the rshim misc log. OobUpdate does not check the rshim log and reports "Upgrade finished!" with no indication that BMC and CEC firmware were not updated.

Suggested change:
During the wait for DPU ready after a BUNDLE update, poll the rshim misc log for the VLAN error. If detected, print a warning after the version table. The rshim log is volatile and cleared when the DPU reboots from eMMC, so it is polled every 5 seconds to catch the narrow window between the error being logged and the log being cleared.

Why:
The OobUpdate tool should indicate that BMC and CEC firmware were not updated when VLAN 4040 is down, as described in the issue.

bump version to 1.8.9

