### PR TITLE
Fail fast when SSH credentials are missing for CONFIG update (#4996660)

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.9'
+Version = '1.9.0'
 task_dir = None
 debug = False
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -546,11 +546,11 @@ def main():
 
         dpu_part_number = dpu_update.get_dpu_part_number()
         if dpu_part_number == '900-9D3B6-F2SV-PA0':
-            print('DPU Part Number is 900-9D3B6-F2SV-PA0, set EnableDdr5600 to false')
-            # Set EnableDdr5600 to false
-            if not dpu_update.disable_ddr5600():
-                print('Failed to set EnableDdr5600 to false')
-                return 1
+            if bfb_file_md5 not in BFB_292_54_MD5_LIST + BFB_293_39_MD5_LIST:
+                print('DPU Part Number is 900-9D3B6-F2SV-PA0, set EnableDdr5600 to false')
+                if not dpu_update.disable_ddr5600():
+                    print('Failed to set EnableDdr5600 to false')
+                    return 1
 
         return 0
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.5'
+Version = '1.8.6'
 task_dir = None
 debug = False
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.6'
+Version = '1.8.7'
 task_dir = None
 debug = False
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -544,14 +544,6 @@ def main():
         if args.clear_config:
             dpu_update.reset_config()
 
-        dpu_part_number = dpu_update.get_dpu_part_number()
-        if dpu_part_number == '900-9D3B6-F2SV-PA0':
-            if bfb_file_md5 not in BFB_292_54_MD5_LIST + BFB_293_39_MD5_LIST:
-                print('DPU Part Number is 900-9D3B6-F2SV-PA0, set EnableDdr5600 to false')
-                if not dpu_update.disable_ddr5600():
-                    print('Failed to set EnableDdr5600 to false')
-                    return 1
-
         return 0
 
     except bf_dpu_update.Err_Exception as e:

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.9.0'
+Version = '1.9.1'
 task_dir = None
 debug = False
 
@@ -266,6 +266,15 @@ def pick_config_bfb(args):
     # Nothing found
     return None
 
+def get_update_requiring_ssh(args):
+    if args.module == 'BUNDLE':
+        return 'BUNDLE'
+    if args.module == 'CONFIG':
+        return 'CONFIG'
+    if args.config_file is not None and not args.show_all_versions:
+        return 'CONFIG'
+    return None
+
 def main():
     parser = get_arg_parser()
     args   = parser.parse_args()
@@ -309,6 +318,11 @@ def main():
         except OSError as e:
             print("Error creating directory {}: {}".format(task_dir, e))
             return 1
+
+    ssh_required_update = get_update_requiring_ssh(args)
+    if ssh_required_update and (not args.ssh_username or not args.ssh_password):
+        print("SSH Username -S and SSH Password -K are required for {} update".format(ssh_required_update))
+        return 1
 
     # ---------------------------------------------------------------------
     # Special-case policy:
@@ -386,10 +400,6 @@ def main():
             return 1
 
         if args.module == 'BUNDLE':
-            if not args.ssh_username or not args.ssh_password:
-                print("SSH Username -S and SSH Password -K are required for BUNDLE update")
-                return 1
-
             # Only call file creation and merging functions when executing upgrade actions with -T BUNDLE
             # Create configuration file
             cfg_file_path = create_cfg_file(args.username, args.password, args.ssh_username, args.ssh_password, task_dir, args.task_id, args.lfwp, args.with_config, args.bfcfg)

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -544,6 +544,8 @@ def main():
         if args.clear_config:
             dpu_update.reset_config()
 
+        dpu_update.disable_ddr5600()
+
         return 0
 
     except bf_dpu_update.Err_Exception as e:

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -544,7 +544,13 @@ def main():
         if args.clear_config:
             dpu_update.reset_config()
 
-        dpu_update.disable_ddr5600()
+        dpu_part_number = dpu_update.get_dpu_part_number()
+        if dpu_part_number == '900-9D3B6-F2SV-PA0':
+            print('DPU Part Number is 900-9D3B6-F2SV-PA0, set EnableDdr5600 to false')
+            # Set EnableDdr5600 to false
+            if not dpu_update.disable_ddr5600():
+                print('Failed to set EnableDdr5600 to false')
+                return 1
 
         return 0
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.7'
+Version = '1.8.8'
 task_dir = None
 debug = False
 
@@ -314,8 +314,8 @@ def main():
     # Special-case policy:
     # If the firmware image MD5 is the forbidden one, ignore --with-config.
     # This uses MD5 (not filename) to prevent evasion via renaming.
-    # Forbidden --with-config BFB image: 
-    # BFB_292_54 MD5: 
+    # Forbidden --with-config BFB image:
+    # BFB_292_54 MD5:
     # 11423d3b87938567b00afbfe2cb9aa03 bf-fwbundle-2.9.2-54_25.02-prod-900-9D3B6-F2SV-PA0_Ax.bfb
     # fc73aab423c9fa4d67a383128eff4b8a bf-fwbundle-2.9.2-54_25.02-prod-900-9D3B6-F2SC-EA0_Ax.bfb
     # downgrade to 2.9.2-54 need to be separated into 2 parts: downgrade config version first, then downgrade FWbundle

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.4'
+Version = '1.8.5'
 task_dir = None
 debug = False
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.3'
+Version = '1.8.4'
 task_dir = None
 debug = False
 

--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.8.8'
+Version = '1.8.9'
 task_dir = None
 debug = False
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1840,28 +1840,6 @@ class BF_DPU_Update(object):
             self._wait_for_dpu_ready()
             self._wait_for_system_power_on()
 
-        dpu_part_number = self.get_dpu_part_number()
-        if dpu_part_number == '900-9D3B6-F2SV-PA0':
-            print('DPU Part Number is 900-9D3B6-F2SV-PA0, set DDR frequency to 5200MHz')
-            # Set DDR frequency to 5200MHz
-            enable_ddr5600 = self.get_ddr_frequency()
-            if self.debug:
-                print('Enable_Ddr5600 frequency: ', enable_ddr5600)
-            if enable_ddr5600:
-                self.set_ddr_frequency(False)
-                while self.get_ddr_frequency():
-                    time.sleep(10)
-            else:
-                self.set_ddr_frequency(True)
-                while not self.get_ddr_frequency():
-                    time.sleep(10)
-                self.set_ddr_frequency(False)
-                while self.get_ddr_frequency():
-                    time.sleep(10)
-
-            self.reboot_system()
-            self._wait_for_system_power_on()
-
         if self.reset_bios and not self.lfwp:
             # This DPU reset is required to apply the configuration that was downloaded from the BMC during the previous boot
             self.send_reset_bios()
@@ -1906,6 +1884,31 @@ class BF_DPU_Update(object):
             nic_fw_ver = self.get_ver('NIC')
             if bfb_nic_fw_ver != nic_fw_ver:
                 print('\nWARNING: NIC firmware update done. Live Patch NIC Firmware reset is not supported.')
+
+        return True
+
+    def disable_ddr5600(self):
+        dpu_part_number = self.get_dpu_part_number()
+        if dpu_part_number == '900-9D3B6-F2SV-PA0':
+            print('DPU Part Number is 900-9D3B6-F2SV-PA0, set DDR frequency to 5200MHz')
+            # Set DDR frequency to 5200MHz
+            enable_ddr5600 = self.get_ddr_frequency()
+            if self.debug:
+                print('Enable_Ddr5600 frequency: ', enable_ddr5600)
+            if enable_ddr5600:
+                self.set_ddr_frequency(False)
+                while self.get_ddr_frequency():
+                    time.sleep(10)
+            else:
+                self.set_ddr_frequency(True)
+                while not self.get_ddr_frequency():
+                    time.sleep(10)
+                self.set_ddr_frequency(False)
+                while self.get_ddr_frequency():
+                    time.sleep(10)
+
+            self.reboot_system()
+            self._wait_for_system_power_on()
 
         return True
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1691,6 +1691,29 @@ class BF_DPU_Update(object):
             raise Err_Exception(Err_Num.BAD_RESPONSE_FORMAT, 'Failed to extract DPU mode')
         return mode
 
+    def get_ddr_frequency(self):
+        url = self._get_url_base() + '/Systems/Bluefield/Bios'
+        response = self._http_get(url)
+        self.log('Get EnableDdr5600', response)
+        self._handle_status_code(response, [200])
+        return response.json()['Attributes']['EnableDdr5600']
+
+    def set_ddr_frequency(self, enable_ddr5600):
+        if self.debug:
+            print("Set EnableDdr5600 to {}".format(enable_ddr5600))
+        url = self._get_url_base() + '/Systems/Bluefield/Bios/Settings'
+        headers = {
+            'Content-Type' : 'application/json'
+        }
+        data = {
+            'Attributes': {
+                'EnableDdr5600': enable_ddr5600,
+            },
+        }
+        response = self._http_patch(url, data=json.dumps(data), headers=headers)
+        self.log('Set EnableDdr5600 to false:', response)
+        self._handle_status_code(response, [200])
+        self.reboot_system()
 
     def _wait_for_dpu_ready(self):
         print('Waiting for the BFB installation to finish')
@@ -1817,6 +1840,28 @@ class BF_DPU_Update(object):
             self._wait_for_dpu_ready()
             self._wait_for_system_power_on()
 
+        dpu_part_number = self.get_dpu_part_number()
+        if dpu_part_number == '900-9D3B6-F2SV-PA0':
+            print('DPU Part Number is 900-9D3B6-F2SV-PA0, set DDR frequency to 5200MHz')
+            # Set DDR frequency to 5200MHz
+            enable_ddr5600 = self.get_ddr_frequency()
+            if self.debug:
+                print('Enable_Ddr5600 frequency: ', enable_ddr5600)
+            if enable_ddr5600:
+                self.set_ddr_frequency(False)
+                while self.get_ddr_frequency():
+                    time.sleep(10)
+            else:
+                self.set_ddr_frequency(True)
+                while not self.get_ddr_frequency():
+                    time.sleep(10)
+                self.set_ddr_frequency(False)
+                while self.get_ddr_frequency():
+                    time.sleep(10)
+
+            self.reboot_system()
+            self._wait_for_system_power_on()
+
         if self.reset_bios and not self.lfwp:
             # This DPU reset is required to apply the configuration that was downloaded from the BMC during the previous boot
             self.send_reset_bios()
@@ -1910,6 +1955,21 @@ class BF_DPU_Update(object):
         self.log('Reboot DPU system', response)
         self._handle_status_code(response, [200, 204])
 
+    def get_dpu_part_number(self):
+        try:
+            url = self._get_url_base() + '/Systems/Bluefield'
+            response = self._http_get(url)
+            self.log('Get DPU Part Number', response)
+            self._handle_status_code(response, [200])
+        except Exception as e:
+            return ''
+
+        part_number = ''
+        try:
+            part_number = response.json()['PartNumber']
+        except Exception as e:
+            raise Err_Exception(Err_Num.BAD_RESPONSE_FORMAT, 'Failed to extract DPU Part Number')
+        return part_number
 
     def get_system_power_state(self):
         try:

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -702,7 +702,7 @@ class BF_DPU_Update(object):
         return self.simple_update_impl('SCP', self._format_ip(self._get_local_ip()) + '/' + os.path.abspath(self.fw_file_path))
 
 
-    def run_command_on_bmc(self, command, exit_on_error=True):
+    def run_command_on_bmc(self, command, exit_on_error=True, best_effort=False):
         self.log("Run command on BMC: {}".format(command))
         rc, output = (0, '')
         try:
@@ -722,11 +722,19 @@ class BF_DPU_Update(object):
             else:
                 err_num = Err_Num.OTHER_EXCEPTION
 
-            # Report to console/rshim
             if err_num == Err_Num.INVALID_USERNAME_OR_PASSWORD and self.ssh_username:
                 self.error_reporter.report_ssh_authentication_failure(
                     self._format_ip(self.bmc_ip), self.ssh_username)
-            elif err_num == Err_Num.BMC_CONNECTION_FAIL:
+                if exit_on_error or best_effort:
+                    raise Err_Exception(err_num, 'Command "{}" failed with return code {}'.format(command, rc))
+                self.console_logger.log_error(f"SSH command failed on BMC: {output}")
+                return output
+
+            if best_effort:
+                # Optional probes treat temporary SSH loss during update as "sample unavailable".
+                return ''
+
+            if err_num == Err_Num.BMC_CONNECTION_FAIL:
                 self.error_reporter.report_connection_failure(
                     self._format_ip(self.bmc_ip), self.bmc_port)
 
@@ -1082,15 +1090,14 @@ class BF_DPU_Update(object):
         ))
 
 
-    def get_bmc_rshim_misc(self):
+    def get_bmc_rshim_misc(self, best_effort=False):
         misc = self.run_command_on_bmc("sshpass -p {password} {ssh} {username}@{ip} '{command}'".format(
             ssh=self.ssh,
             password=self.ssh_password,
             username=self.ssh_username,
             ip=self.bmc_ip,
-            command='/bin/bash -c "cat /dev/rshim0/misc"',
-            exit_on_error=False
-        ))
+            command='/bin/bash -c "cat /dev/rshim0/misc"'
+        ), best_effort=best_effort)
         return misc
 
     def query_golden_image_config_dir_exists_on_bmc(self):
@@ -1815,6 +1822,11 @@ class BF_DPU_Update(object):
             self.disable_runtime_rshim()
             time.sleep(120) # Wait for NIC fw to be updated and mlxfwreset to be done
         else:
+            target_bmc_ver = self.get_info_data_version('BMC')
+            bmc_update_expected = target_bmc_ver not in ['', 'NA'] and target_bmc_ver != old_bmc_ver
+            rshim_poll_enabled = True
+            bmc_reboot_reported = False
+
             # Wait for DPU ready while checking rshim log for VLAN errors.
             # The rshim log is cleared when the DPU reboots from eMMC,
             # so we check it frequently (every 5s) to catch the narrow window
@@ -1832,13 +1844,17 @@ class BF_DPU_Update(object):
                 if state == 'OsIsRunning':
                     self._print_process(100)
                     break
-                if not rshim_vlan_error:
-                    try:
-                        misc = self.get_bmc_rshim_misc()
-                        if 'Failed to create VLAN' in misc:
-                            rshim_vlan_error = True
-                    except Exception:
-                        pass
+                if rshim_poll_enabled and not rshim_vlan_error:
+                    misc = self.get_bmc_rshim_misc(best_effort=True)
+                    if 'Failed to create VLAN' in misc:
+                        rshim_vlan_error = True
+                    elif misc == '' and bmc_update_expected:
+                        # Once the BMC reboot starts, the misc log is no longer useful for VLAN detection.
+                        if not bmc_reboot_reported:
+                            print()
+                            print("BMC is rebooting.")
+                            bmc_reboot_reported = True
+                        rshim_poll_enabled = False
                 self._print_process(100 * (cur - start) / timeout)
                 time.sleep(5)
             print()
@@ -2238,13 +2254,14 @@ class BF_DPU_Update(object):
 
         for member in self.info_data["Members"]:
             if member["Name"] == info_module[module]:
+                version = member["Version"]
                 if member["Name"] == "BF3_BMC_FW":
-                    member["Version"] = "BF-" + member["Version"]
+                    version = "BF-" + version
                 elif member["Name"] == "BF3_CEC_FW":
-                    member["Version"] = member["Version"] + "_n02"
+                    version = version + "_n02"
                 elif member["Name"] == "BF3_ATF":
-                    member["Version"] = self.extract_atf_uefi_ver_from_fw_file()
-                return member["Version"]
+                    version = self.extract_atf_uefi_ver_from_fw_file()
+                return version
         return 'NA'
 
     def show_old_new_versions(self, old_vers, new_vers, filter = []):

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1691,47 +1691,6 @@ class BF_DPU_Update(object):
             raise Err_Exception(Err_Num.BAD_RESPONSE_FORMAT, 'Failed to extract DPU mode')
         return mode
 
-    def get_ddr_frequency(self):
-        url = self._get_url_base() + '/Systems/Bluefield/Bios'
-        response = self._http_get(url)
-        self.log('Get EnableDdr5600', response)
-        self._handle_status_code(response, [200])
-        return response.json()['Attributes']['EnableDdr5600']
-
-    def set_ddr_frequency(self, enable_ddr5600):
-        if self.debug:
-            print("Set EnableDdr5600 to {}".format(enable_ddr5600))
-        url = self._get_url_base() + '/Systems/Bluefield/Bios/Settings'
-        headers = {
-            'Content-Type' : 'application/json'
-        }
-        data = {
-            'Attributes': {
-                'EnableDdr5600': enable_ddr5600,
-            },
-        }
-        response = self._http_patch(url, data=json.dumps(data), headers=headers)
-        self.log('Set EnableDdr5600 to false:', response)
-        self._handle_status_code(response, [200])
-        self.reboot_system()
-
-    def _wait_for_ddr_frequency_change(self, enable_ddr5600):
-        rc = True
-        timeout = 60 * 5 # Wait up to 5 minutes
-        start   = int(time.time())
-        end     = start + timeout
-        while True:
-            cur = int(time.time())
-            if cur > end:
-                self.log('DDR frequency change timeout')
-                rc = False
-                break
-            time.sleep(10)
-            if self.get_ddr_frequency() == enable_ddr5600:
-                if self.debug:
-                    print('DDR frequency changed to {}'.format(enable_ddr5600))
-                break
-        return rc
 
     def _wait_for_dpu_ready(self):
         print('Waiting for the BFB installation to finish')
@@ -1905,27 +1864,6 @@ class BF_DPU_Update(object):
 
         return True
 
-    def disable_ddr5600(self):
-        enable_ddr5600 = self.get_ddr_frequency()
-        if self.debug:
-            print('Enable_Ddr5600 frequency: ', enable_ddr5600)
-        if enable_ddr5600:
-            self.set_ddr_frequency(False)
-            if not self._wait_for_ddr_frequency_change(False):
-                return False
-        else:
-            self.set_ddr_frequency(True)
-            if not self._wait_for_ddr_frequency_change(True):
-                return False
-            self.set_ddr_frequency(False)
-            if not self._wait_for_ddr_frequency_change(False):
-                return False
-
-        self.reboot_system()
-        self._wait_for_system_power_on()
-
-        return True
-
 
     def send_reset_bios(self):
         print("Factory reset BIOS configuration (ResetBios) (will reboot the system)")
@@ -1972,21 +1910,6 @@ class BF_DPU_Update(object):
         self.log('Reboot DPU system', response)
         self._handle_status_code(response, [200, 204])
 
-    def get_dpu_part_number(self):
-        try:
-            url = self._get_url_base() + '/Chassis/Bluefield_BMC'
-            response = self._http_get(url)
-            self.log('Get DPU Part Number', response)
-            self._handle_status_code(response, [200])
-        except Exception as e:
-            return ''
-
-        part_number = ''
-        try:
-            part_number = response.json()['PartNumber']
-        except Exception as e:
-            raise Err_Exception(Err_Num.BAD_RESPONSE_FORMAT, 'Failed to extract DPU Part Number')
-        return part_number
 
     def get_system_power_state(self):
         try:

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1715,6 +1715,24 @@ class BF_DPU_Update(object):
         self._handle_status_code(response, [200])
         self.reboot_system()
 
+    def _wait_for_ddr_frequency_change(self, enable_ddr5600):
+        rc = True
+        timeout = 60 * 5 # Wait up to 5 minutes
+        start   = int(time.time())
+        end     = start + timeout
+        while True:
+            cur = int(time.time())
+            if cur > end:
+                self.log('DDR frequency change timeout')
+                rc = False
+                break
+            time.sleep(10)
+            if self.get_ddr_frequency() == enable_ddr5600:
+                if self.debug:
+                    print('DDR frequency changed to {}'.format(enable_ddr5600))
+                break
+        return rc
+
     def _wait_for_dpu_ready(self):
         print('Waiting for the BFB installation to finish')
         timeout = 60 * 40 # Wait up to 40 minutes
@@ -1888,27 +1906,23 @@ class BF_DPU_Update(object):
         return True
 
     def disable_ddr5600(self):
-        dpu_part_number = self.get_dpu_part_number()
-        if dpu_part_number == '900-9D3B6-F2SV-PA0':
-            print('DPU Part Number is 900-9D3B6-F2SV-PA0, set DDR frequency to 5200MHz')
-            # Set DDR frequency to 5200MHz
-            enable_ddr5600 = self.get_ddr_frequency()
-            if self.debug:
-                print('Enable_Ddr5600 frequency: ', enable_ddr5600)
-            if enable_ddr5600:
-                self.set_ddr_frequency(False)
-                while self.get_ddr_frequency():
-                    time.sleep(10)
-            else:
-                self.set_ddr_frequency(True)
-                while not self.get_ddr_frequency():
-                    time.sleep(10)
-                self.set_ddr_frequency(False)
-                while self.get_ddr_frequency():
-                    time.sleep(10)
+        enable_ddr5600 = self.get_ddr_frequency()
+        if self.debug:
+            print('Enable_Ddr5600 frequency: ', enable_ddr5600)
+        if enable_ddr5600:
+            self.set_ddr_frequency(False)
+            if not self._wait_for_ddr_frequency_change(False):
+                return False
+        else:
+            self.set_ddr_frequency(True)
+            if not self._wait_for_ddr_frequency_change(True):
+                return False
+            self.set_ddr_frequency(False)
+            if not self._wait_for_ddr_frequency_change(False):
+                return False
 
-            self.reboot_system()
-            self._wait_for_system_power_on()
+        self.reboot_system()
+        self._wait_for_system_power_on()
 
         return True
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1974,7 +1974,7 @@ class BF_DPU_Update(object):
 
     def get_dpu_part_number(self):
         try:
-            url = self._get_url_base() + '/Systems/Bluefield'
+            url = self._get_url_base() + '/Chassis/Bluefield_BMC'
             response = self._http_get(url)
             self.log('Get DPU Part Number', response)
             self._handle_status_code(response, [200])

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1810,11 +1810,38 @@ class BF_DPU_Update(object):
         if self.lfwp:
             self.enable_runtime_rshim()
         self._start_and_wait_simple_update_task()
+        rshim_vlan_error = False
         if self.lfwp:
             self.disable_runtime_rshim()
             time.sleep(120) # Wait for NIC fw to be updated and mlxfwreset to be done
         else:
-            self._wait_for_dpu_ready()
+            # Wait for DPU ready while checking rshim log for VLAN errors.
+            # The rshim log is cleared when the DPU reboots from eMMC,
+            # so we check it frequently (every 5s) to catch the narrow window
+            # between the error being logged and the log being cleared.
+            print('Waiting for the BFB installation to finish')
+            timeout = 60 * 40
+            start = int(time.time())
+            end   = start + timeout
+            while True:
+                cur = int(time.time())
+                if cur > end:
+                    self._print_process(100)
+                    break
+                state = self.get_dpu_boot_state()
+                if state == 'OsIsRunning':
+                    self._print_process(100)
+                    break
+                if not rshim_vlan_error:
+                    try:
+                        misc = self.get_bmc_rshim_misc()
+                        if 'Failed to create VLAN' in misc:
+                            rshim_vlan_error = True
+                    except Exception:
+                        pass
+                self._print_process(100 * (cur - start) / timeout)
+                time.sleep(5)
+            print()
             self._wait_for_system_power_on()
 
         if self.reset_bios and not self.lfwp:
@@ -1855,6 +1882,9 @@ class BF_DPU_Update(object):
         self._check_and_clear_sel_if_needed(old_bmc_ver, new_bmc_ver)
 
         self.show_old_new_versions(cur_vers, new_vers, ['BMC', 'CEC', 'ATF', 'UEFI', 'NIC'])
+
+        if rshim_vlan_error:
+            print('\nWARNING: BMC components upgrade was skipped. VLAN error detected in rshim log.')
 
         if self.lfwp:
             bfb_nic_fw_ver = self.get_info_data_version('NIC')

--- a/workaround/bf-4957032.cfg
+++ b/workaround/bf-4957032.cfg
@@ -1,9 +1,0 @@
-
-bmc_custom_action4()
-{
-	if [ "$dpu_part_number" == "900-9D3B6-F2SV-PA0_Ax" ]; then
-		ilog "Set EnableDdr5600 to true as an optimization. It will be set to false later."
-		output=$(curl -ksS -u "$BMC_USER:$BMC_PASSWORD" -H "Content-Type: application/json" -X PATCH "https://${BMC_IP}/redfish/v1/Systems/Bluefield/Bios/Settings" -d '{"Attributes":{"EnableDdr5600":true}}' 2>&1)
-		ilog "Response: $output"
-	fi
-}

--- a/workaround/bf-4957032.cfg
+++ b/workaround/bf-4957032.cfg
@@ -1,0 +1,9 @@
+
+bmc_custom_action4()
+{
+	if [ "$dpu_part_number" == "900-9D3B6-F2SV-PA0_Ax" ]; then
+		ilog "Set EnableDdr5600 to true as an optimization. It will be set to false later."
+		output=$(curl -ksS -u "$BMC_USER:$BMC_PASSWORD" -H "Content-Type: application/json" -X PATCH "https://${BMC_IP}/redfish/v1/Systems/Bluefield/Bios/Settings" -d '{"Attributes":{"EnableDdr5600":true}}' 2>&1)
+		ilog "Response: $output"
+	fi
+}


### PR DESCRIPTION
### Initial state

When running OobUpdate with `-T CONFIG` (or any module combined with `--config <file>`) but omitting `-S`/`-K` (SSH credentials), the tool did not validate the missing arguments up-front. It proceeded with literal `None` as the SSH user/password, pushed the BFB to the BMC, then failed the SSH handshake during the on-BMC apply. The failure triggered the BMC reboot recovery path, rebooting the BMC for what should have been a 2-second argparse-level error.

Only `-T BUNDLE` was previously validated.

### Suggested change

Add a CLI preflight that fails fast if SSH credentials are missing for any update path that requires SSH. Covers:
- `-T BUNDLE` (kept existing behavior)
- `-T CONFIG`
- Any `-T <module>` combined with `--config <file>`

A small helper `get_update_requiring_ssh()` determines if SSH is needed, and a single validation block prints a clear error and exits before any BMC operation, BFB upload, or SSH attempt.

### Why

Missing SSH credentials should produce a clear error, not an unintended BMC reboot. The reboot is destructive on shared setups and confusing for users. Failing fast at the argparse level matches the existing BUNDLE behavior and prevents the recovery code from firing on what is really a user-input error.


Bump version from `1.9.0` to `1.9.1`.

