### PR TITLE
Fail fast when SSH credentials are missing for CONFIG update (#4996660)

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.9.0'
+Version = '1.9.1'
 task_dir = None
 debug = False
 
@@ -266,6 +266,15 @@ def pick_config_bfb(args):
     # Nothing found
     return None
 
+def get_update_requiring_ssh(args):
+    if args.module == 'BUNDLE':
+        return 'BUNDLE'
+    if args.module == 'CONFIG':
+        return 'CONFIG'
+    if args.config_file is not None and not args.show_all_versions:
+        return 'CONFIG'
+    return None
+
 def main():
     parser = get_arg_parser()
     args   = parser.parse_args()
@@ -309,6 +318,11 @@ def main():
         except OSError as e:
             print("Error creating directory {}: {}".format(task_dir, e))
             return 1
+
+    ssh_required_update = get_update_requiring_ssh(args)
+    if ssh_required_update and (not args.ssh_username or not args.ssh_password):
+        print("SSH Username -S and SSH Password -K are required for {} update".format(ssh_required_update))
+        return 1
 
     # ---------------------------------------------------------------------
     # Special-case policy:
@@ -386,10 +400,6 @@ def main():
             return 1
 
         if args.module == 'BUNDLE':
-            if not args.ssh_username or not args.ssh_password:
-                print("SSH Username -S and SSH Password -K are required for BUNDLE update")
-                return 1
-
             # Only call file creation and merging functions when executing upgrade actions with -T BUNDLE
             # Create configuration file
             cfg_file_path = create_cfg_file(args.username, args.password, args.ssh_username, args.ssh_password, task_dir, args.task_id, args.lfwp, args.with_config, args.bfcfg)


### PR DESCRIPTION
### Initial state

When running OobUpdate with `-T CONFIG` (or any module combined with `--config <file>`) but omitting `-S`/`-K` (SSH credentials), the tool did not validate the missing arguments up-front. It proceeded with literal `None` as the SSH user/password, pushed the BFB to the BMC, then failed the SSH handshake during the on-BMC apply. The failure triggered the BMC reboot recovery path, rebooting the BMC for what should have been a 2-second argparse-level error.

Only `-T BUNDLE` was previously validated.

### Suggested change

Add a CLI preflight that fails fast if SSH credentials are missing for any update path that requires SSH. Covers:
- `-T BUNDLE` (kept existing behavior)
- `-T CONFIG`
- Any `-T <module>` combined with `--config <file>`

A small helper `get_update_requiring_ssh()` determines if SSH is needed, and a single validation block prints a clear error and exits before any BMC operation, BFB upload, or SSH attempt.

### Why

Missing SSH credentials should produce a clear error, not an unintended BMC reboot. The reboot is destructive on shared setups and confusing for users. Failing fast at the argparse level matches the existing BUNDLE behavior and prevents the recovery code from firing on what is really a user-input error.

Bump version from `1.9.0` to `1.9.1`.
