### PR TITLE
Gate bundle update on BFB target version match

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.9.2'
+Version = '1.9.3'
 task_dir = None
 debug = False
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Notes:
 
         Upgrade finished!
 
+If any of BMC, CEC, ATF, UEFI or NIC fail to come up at the BFB target version after the update completes, the script now exits non-zero with an error listing the components that did not activate, instead of printing `Upgrade finished!`. This catches cases where a component was staged but never activated by the BFB installer (for example, when a CEC reset interrupts the BFB-Installer mid-flow).
+
 
 ### Update Config Image
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1908,6 +1908,25 @@ class BF_DPU_Update(object):
             if bfb_nic_fw_ver != nic_fw_ver:
                 print('\nWARNING: NIC firmware update done. Live Patch NIC Firmware reset is not supported.')
 
+        if not rshim_vlan_error:
+            mismatched = []
+            for module in ['BMC', 'CEC', 'ATF', 'UEFI', 'NIC']:
+                if module == 'NIC' and self.lfwp:
+                    continue
+                bfb_ver = self.get_info_data_version(module)
+                if bfb_ver in ('', 'NA'):
+                    continue
+                actual_ver = new_vers.get(module, '')
+                if actual_ver != bfb_ver:
+                    mismatched.append((module, actual_ver, bfb_ver))
+            if mismatched:
+                raise Err_Exception(
+                    Err_Num.COMPONENT_NOT_ACTIVATED,
+                    'Components not at BFB target version: ' + ', '.join(
+                        '{} (running {!r}, expected {!r})'.format(m, a, e) for m, a, e in mismatched
+                    )
+                )
+
         return True
 
 

--- a/src/error_num.py
+++ b/src/error_num.py
@@ -49,6 +49,7 @@ class Err_Num(Enum):
     UPDATE_SERVICE_NOT_READY              = 38
     NO_PENDING_CEC_FW                     = 39
     BMC_GOLDEN_IMAGE_CONFIG_DIR_ERR       = 40
+    COMPONENT_NOT_ACTIVATED               = 41
     OTHER_EXCEPTION                       = 127
 
 
@@ -93,6 +94,7 @@ Err_Str = {
    Err_Num.UPDATE_SERVICE_NOT_READY       : 'Update service is not ready(enabled)',
    Err_Num.NO_PENDING_CEC_FW              : 'CEC firmware was not updated',
    Err_Num.BMC_GOLDEN_IMAGE_CONFIG_DIR_ERR : 'NO /tmp/golden-image-config DIR on BMC',
+   Err_Num.COMPONENT_NOT_ACTIVATED        : 'One or more components were not updated to the BFB target version',
    Err_Num.OTHER_EXCEPTION                : 'Other Errors',
 }
 


### PR DESCRIPTION
### Current state

OobUpdate.py BUNDLE flow ended with a print-only OLD/NEW/BFB version table and unconditionally printed "Upgrade finished!" with rc=0. update_bundle() returned True regardless of whether the running versions on the DPU matched the firmware in the BFB. When the BFB installer was interrupted mid-flow (e.g. a CEC reset killing the remaining BMC reboot and NIC firmware steps), the script silently reported success while BMC, CEC and NIC stayed on the old image.

### Change

Added a verification gate at the end of update_bundle() that walks BMC/CEC/ATF/UEFI/NIC, fetches the BFB target version via get_info_data_version(), and compares it against the post-update running version with strict equality. On any mismatch the gate raises Err_Exception with a new error number, which propagates up through OobUpdate.main() so the script exits non-zero and never prints "Upgrade finished!". The gate honors the existing skip paths: it is bypassed when rshim_vlan_error is set (BMC components were intentionally skipped) and skips the NIC module under --lfwp (the existing LFWP warning already covers that case). Modules whose BFB target is empty/NA are skipped as well. Bumped Version to 1.9.3.

### Why

Without the gate, a successful exit code from OobUpdate is not evidence that the firmware update actually took effect, which is exactly how this bug went unnoticed in QA. The gate turns silent activation failures into loud, actionable errors that list which components were not at the BFB target version, while leaving the known intentional-skip paths intact.

Issue: 5015602