### PR TITLE
Retry Bios.ResetBios on transient bmcweb unavailability (#5015660)

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.9.1'
+Version = '1.9.2'
 task_dir = None
 debug = False
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1917,9 +1917,17 @@ class BF_DPU_Update(object):
         headers = {
             'Content-Type' : 'application/json'
         }
-        response = self._http_post(url, data=None, headers=headers)
-        self.log('Factory Reset BIOS (ResetBios)', response)
-        self._handle_status_code(response, [200])
+        try:
+            response = self._http_post(url, data=None, headers=headers)
+            self.log('Factory Reset BIOS (ResetBios)', response)
+            self._handle_status_code(response, [200])
+        except Err_Exception:
+            # bmcweb may be briefly unreachable right after the BFB-induced
+            # BMC reboot; wait for it to come back and retry once.
+            self._wait_for_bmc_on(False)
+            response = self._http_post(url, data=None, headers=headers)
+            self.log('Factory Reset BIOS (ResetBios)', response)
+            self._handle_status_code(response, [200])
         # ResetBios command will send config image to DPU by rshim
         # That will reset the DPU automatically. No need to reboot it again
         # self.reboot_system()


### PR DESCRIPTION
### Initial state

During a Bundle upgrade with `--with-config`, after the BFB-induced BMC reboot, `update_bundle()` immediately fires a Redfish `Bios.ResetBios` POST. The DPU SOC's `PowerState` reads `On`, but bmcweb (the BMC's Redfish service) can briefly be unreachable as it continues to settle. The single `_http_post` call has no retry around it: on a curl `rc=7` ("Failed to connect to host"), the call raises `Err_Num.CURL_COMMAND_FAILED` and `OobUpdate.sh` exits `rc=30`.

QA reproduced this in the Feb LTS U2 → APR GA bundle flow on the ByteDance FLF setup. The previous `_wait_for_system_power_on()` only verifies the DPU SOC is powered on; it does not prove that bmcweb will still be answering on the very next call.

### Suggested change

Wrap the `Bios.ResetBios` POST in `send_reset_bios()` in a `try/except Err_Exception`. On any `Err_Exception`, call the existing `_wait_for_bmc_on(False)` helper (polls every 4 s for up to 3 minutes until the BMC answers `_get_ver('BMC')` and `_get_ver('CEC')`), then retry the POST once. A second failure propagates naturally with the original `Err_Exception`.

No new constants, no extra sleeps, no error-code substitution. `Bios.ResetBios` is idempotent on the BMC side, so a duplicate POST is harmless if a prior attempt slipped through.

### Why

The same pattern is already used in `get_dpu_boot_state()` (`src/bf_dpu_update.py:1660-1682`) — a Redfish call that runs near a BMC reboot and may transiently fail. Mirroring it keeps the change minimal and familiar to reviewers, and matches existing codebase conventions (re-raise the original `Err_Exception` rather than substitute a "nicer" `Err_Num`).

`_wait_for_bmc_on` waits on actual Redfish-readiness evidence — two successful GETs back-to-back — rather than a fixed sleep. Its 3-minute ceiling gives bmcweb time to come back without masking a genuinely broken BMC: if it does not recover, the original `Err_Exception` propagates and the script still exits with the original error code, just after a real recovery attempt instead of giving up immediately.

Happy path is unchanged: zero added time when the first POST succeeds.
