### PR TITLE
Exclude NIC from BFB target verification gate

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.9.3'
+Version = '1.9.4'
 task_dir = None
 debug = False
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Notes:
 
         Upgrade finished!
 
-If any of BMC, CEC, ATF, UEFI or NIC fail to come up at the BFB target version after the update completes, the script now exits non-zero with an error listing the components that did not activate, instead of printing `Upgrade finished!`. This catches cases where a component was staged but never activated by the BFB installer (for example, when a CEC reset interrupts the BFB-Installer mid-flow).
+If any of BMC, CEC, ATF or UEFI fail to come up at the BFB target version after the update completes, the script now exits non-zero with an error listing the components that did not activate, instead of printing `Upgrade finished!`. This catches cases where a component was staged but never activated by the BFB installer (for example, when a CEC reset interrupts the BFB-Installer mid-flow). NIC firmware is intentionally excluded from this verification because a NIC firmware update can be staged and only take effect after a host power cycle, so the running version at script exit can legitimately differ from the BFB target.
 
 
 ### Update Config Image

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -1909,10 +1909,12 @@ class BF_DPU_Update(object):
                 print('\nWARNING: NIC firmware update done. Live Patch NIC Firmware reset is not supported.')
 
         if not rshim_vlan_error:
+            # NIC is excluded: a NIC firmware downgrade (or any update where
+            # mlxfwreset does not run in-flow) is staged on the card and only
+            # takes effect after a host power cycle, so the running version
+            # at script exit can legitimately differ from the BFB target.
             mismatched = []
-            for module in ['BMC', 'CEC', 'ATF', 'UEFI', 'NIC']:
-                if module == 'NIC' and self.lfwp:
-                    continue
+            for module in ['BMC', 'CEC', 'ATF', 'UEFI']:
                 bfb_ver = self.get_info_data_version(module)
                 if bfb_ver in ('', 'NA'):
                     continue


### PR DESCRIPTION
### Current state

Commit 04ebed1 (1.9.3) added a post-update verification gate at the end of update_bundle() that compares each component's running version against the BFB target version and raises
COMPONENT_NOT_ACTIVATED on mismatch. The gate covered BMC/CEC/ATF/UEFI/NIC and only skipped NIC under --lfwp.

### Change

Drop NIC from the verified module list. The now-unreachable "module == 'NIC' and self.lfwp" skip branch is removed with it. The existing LFWP-only NIC warning at the top of the post-update section is left untouched. Bump Version to 1.9.4 and update README to describe the narrower scope and the reason NIC is excluded.

### Why

On BF3 a NIC firmware update can be staged on the card during the BFB flow and only take effect after a host power cycle. In particular, NIC firmware downgrades cannot be applied by mlxfwreset in-flow and the new image only activates on the next cold boot. The Redfish FirmwareInventory entry for DPU_NIC exposes only the running Version field on this BMC generation (the staged/pending inventory model is BF4 PLDM-only), so the gate as written would false-fail every legitimate
staged-but-not-yet-active NIC update and flag a successful run as a failure. The original silent-success bug remains closed for BMC/CEC/ATF/UEFI, which is what actually broke in 5018758.

Issue: 5018758