### PR TITLE
Cap rshim-misc SSH poll at 30s to prevent multi-hour hang (#5032955)

### DIFF
--- a/OobUpdate.py
+++ b/OobUpdate.py
@@ -21,7 +21,7 @@ import hashlib
 from error_num import Err_Exception, Err_Num
 
 # Version of this script tool
-Version = '1.9.4'
+Version = '1.9.5'
 task_dir = None
 debug = False
 

--- a/src/bf_dpu_update.py
+++ b/src/bf_dpu_update.py
@@ -702,16 +702,21 @@ class BF_DPU_Update(object):
         return self.simple_update_impl('SCP', self._format_ip(self._get_local_ip()) + '/' + os.path.abspath(self.fw_file_path))
 
 
-    def run_command_on_bmc(self, command, exit_on_error=True, best_effort=False):
+    def run_command_on_bmc(self, command, exit_on_error=True, best_effort=False, timeout=None):
         self.log("Run command on BMC: {}".format(command))
         rc, output = (0, '')
         try:
-            output = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True, universal_newlines=True)
+            output = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True, universal_newlines=True, timeout=timeout)
         except subprocess.CalledProcessError as e:
             rc = e.returncode
             output = e.output.strip()
+        except subprocess.TimeoutExpired:
+            self.log('Command "{}" timed out after {}s'.format(command, timeout))
+            if best_effort:
+                return ''
+            raise Err_Exception(Err_Num.OTHER_EXCEPTION, 'Command "{}" timed out after {}s'.format(command, timeout))
         self.log('Output: {}\nError: {}'.format(output, rc))
-        
+
         if rc != 0:
             # Classify error type
             lower_output = output.lower()
@@ -1090,14 +1095,14 @@ class BF_DPU_Update(object):
         ))
 
 
-    def get_bmc_rshim_misc(self, best_effort=False):
+    def get_bmc_rshim_misc(self, best_effort=False, timeout=None):
         misc = self.run_command_on_bmc("sshpass -p {password} {ssh} {username}@{ip} '{command}'".format(
             ssh=self.ssh,
             password=self.ssh_password,
             username=self.ssh_username,
             ip=self.bmc_ip,
             command='/bin/bash -c "cat /dev/rshim0/misc"'
-        ), best_effort=best_effort)
+        ), best_effort=best_effort, timeout=timeout)
         return misc
 
     def query_golden_image_config_dir_exists_on_bmc(self):
@@ -1845,7 +1850,7 @@ class BF_DPU_Update(object):
                     self._print_process(100)
                     break
                 if rshim_poll_enabled and not rshim_vlan_error:
-                    misc = self.get_bmc_rshim_misc(best_effort=True)
+                    misc = self.get_bmc_rshim_misc(best_effort=True, timeout=30)
                     if 'Failed to create VLAN' in misc:
                         rshim_vlan_error = True
                     elif misc == '' and bmc_update_expected:


### PR DESCRIPTION
## Initial state

PR #91 (commit `4870841`) added a poll of `/dev/rshim0/misc` over SSH every 5 seconds inside the post-`SimpleUpdate` BFB-install wait loop, to catch the `"Failed to create VLAN"` window before the rshim log is cleared on eMMC reboot. The call goes through `get_bmc_rshim_misc(best_effort=True)` at `src/bf_dpu_update.py:1849`.

The underlying `run_command_on_bmc()` uses `subprocess.check_output(..., shell=True)` with no timeout, and `self.ssh` carries no `ConnectTimeout`. If the BMC sshd accepts the TCP connection but stops responding on the channel (e.g., during eMMC reboot or under heavy I/O), `check_output` blocks the Python thread indefinitely. The loop's 40-minute outer cap is checked only between iterations and is bypassed. Reported in #5032955.

## Suggested change

Add an opt-in `timeout=None` kwarg to `run_command_on_bmc()` and thread it through `get_bmc_rshim_misc()`. The BFB-install poll site at `src/bf_dpu_update.py:1849` opts in with `timeout=30`. No other call site passes the kwarg, so `subprocess.check_output(timeout=None)` stays equivalent to no-timeout and all other SSH callers remain bit-for-bit unchanged.

On `subprocess.TimeoutExpired` with `best_effort=True`, return `''`, the same sentinel the existing `CalledProcessError` path produces, which the loop already handles via the `misc == '' and bmc_update_expected` branch at line 1856. On `best_effort=False`, raise `Err_Exception(OTHER_EXCEPTION, ...)`. A `self.log(...)` line in the except block leaves a forensic trace in `-d` mode.

## Why

Reusing the existing empty-string sentinel keeps the change behaviorally additive. The same `bmc_update_expected` mitigation that already absorbs transient `CalledProcessError`-driven empty responses now also absorbs timeout-driven ones.

`timeout=30` is 6x the BFB poll interval (5 s) and half the LFWP poll interval (60 s). A healthy BMC responds in well under 5 s. Worst-case impact per iteration shifts from "blocked forever" to ~30 s, which fits inside the existing 40-min outer cap.

Bump version from `1.9.4` to `1.9.5`.